### PR TITLE
chore: :technologist: Move the devcontainer to arch

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,10 @@
-FROM quay.io/fedora/fedora:41
+FROM ghcr.io/ublue-os/arch-distrobox
 
-RUN dnf update -y && dnf install gtk4-devel ninja-build meson libadwaita-devel dbus-x11 libgee-devel json-glib-devel desktop-file-utils libcurl-devel libglvnd-gles vala-language-server valac git vim -y
+RUN useradd -m -s /bin/bash -G wheel adw && echo 'adw:dev' | chpasswd
+RUN usermod -aG render,video adw
+RUN groupadd docker && usermod -aG docker adw
 
-RUN dnf install -y dnf-plugins-core && \
-    dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
-    dnf install -y docker-ce docker-ce-cli containerd.io
+USER adw
 
-RUN useradd -m -s /bin/bash -G wheel dev && echo 'dev:dev' | sudo chpasswd
-RUN usermod -aG render,video dev
-RUN usermod -aG docker dev
-
-USER dev
+RUN paru -Syu --noconfirm && \
+    paru -S --noconfirm gtk4 ninja meson libadwaita libgee json-glib desktop-file-utils curl libglvnd vala-language-server vala vim docker

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,14 +15,11 @@
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "dev",
+	"remoteUser": "adw",
 	"runArgs": [
 		"--net=host",
 		"--volume=/var/run/docker.sock:/var/run/docker.sock",
 		"--device=/dev/dri"
-	],
-	"mounts": [
-		"source=${localEnv:HOME}/.Xauthority,target=/root/.Xauthority,type=bind,consistency=cached"
 	],
 	"customizations": {
 		"vscode": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,7 @@
         {
             "label": "Launch application",
             "type": "shell",
-            "command": "dbus-daemon --session --fork && ./build/src/com.github.sdv43.whaler",
+            "command": "DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address` ./build/src/com.github.sdv43.whaler",
             "problemMatcher": [],
             "icon": {
                 "id": "run"


### PR DESCRIPTION
Moves the devcontainer to archlinux due to a recent bug in Fedora images where containerized Adwaita apps are desaturated on some window manager / DE / distro.

ArchLinux does not seem have this issue and has all the required versions and packages needed to build this project.

If the bug is fixed, this might get reverted.