### PR TITLE
chore: 🧑‍💻 Move tasks to Just

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,4 +7,4 @@ RUN groupadd docker && usermod -aG docker adw
 USER adw
 
 RUN paru -Syu --noconfirm && \
-    paru -S --noconfirm gtk4 ninja meson libadwaita libgee json-glib desktop-file-utils curl libglvnd vala-language-server vala vim docker
+    paru -S --noconfirm gtk4 ninja meson libadwaita libgee json-glib desktop-file-utils curl libglvnd vala-language-server fzf just vala vim docker

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,9 @@
 				"vivaxy.vscode-conventional-commits",
 				"zachflower.uncrustify",
 				"prince781.vala",
-				"bierner.markdown-preview-github-styles"
+				"bierner.markdown-preview-github-styles",
+				"mkhl.mkhl-just",
+				"nefrob.vscode-just-syntax"
 			]
 		}
 	}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -65,6 +65,15 @@
             "icon": {
                 "id": "browser"
             }
+        },
+        {
+            "label": "Generate valadoc",
+            "type": "shell",
+            "command": "just generate_valadoc",
+            "problemMatcher": [],
+            "icon": {
+                "id": "book"
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Ninja",
             "type": "shell",
-            "command": "cd build && ninja",
+            "command": "just ninja",
             "problemMatcher": [],
             "icon": {
                 "id": "sync"
@@ -15,20 +15,56 @@
         {
             "label": "Install",
             "type": "shell",
-            "command": "cd build && sudo ninja install",
+            "command": "just install",
             "problemMatcher": [],
             "icon": {
-                "id": "arrow-down"
+                "id": "package"
             }
         },
         {
-            "label": "Launch application",
+            "label": "Ninja Run",
             "type": "shell",
-            "command": "DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address` ./build/src/com.github.sdv43.whaler",
+            "command": "just ninja-run",
             "problemMatcher": [],
             "icon": {
-                "id": "run"
+                "id": "play"
             }
         },
+        {
+            "label": "Meson Build",
+            "type": "shell",
+            "command": "just meson-build",
+            "problemMatcher": [],
+            "icon": {
+                "id": "tools"
+            }
+        },
+        {
+            "label": "Meson Reconfigure",
+            "type": "shell",
+            "command": "just meson-reconfigure",
+            "problemMatcher": [],
+            "icon": {
+                "id": "refresh"
+            }
+        },
+        {
+            "label": "Launch",
+            "type": "shell",
+            "command": "just launch",
+            "problemMatcher": [],
+            "icon": {
+                "id": "rocket"
+            }
+        },
+        {
+            "label": "Install Test Browser",
+            "type": "shell",
+            "command": "just install-test-browser",
+            "problemMatcher": [],
+            "icon": {
+                "id": "browser"
+            }
+        }
     ]
 }

--- a/Justfile
+++ b/Justfile
@@ -30,3 +30,6 @@ launch:
 # Install firefox for test xdg-open redirect
 install-test-browser:
     paru -Syu --no-confirm firefox-bin alsa-lib
+
+generate_valadoc:
+    valadoc --package-name="com.github.sdv43.whaler" --vapidir=$(pwd)/vapi --pkg gtk4 --pkg libadwaita-1 --pkg json-glib-1.0 --pkg gio-2.0 --pkg gee-0.8 --pkg posix --pkg libcurl -o docs $(find src -name "*.vala") build/src/Constants.vala build/src/Build.vala

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,32 @@
+export DBUS_SESSION_BUS_ADDRESS := `dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address`
+
+default: ninja-run
+
+# Runs ninja on the project
+[working-directory('build')]
+ninja:
+    ninja
+
+# Installs the schema
+[working-directory('build')]
+install:
+    sudo ninja install
+
+# Run ninja and launch at the same time for quick edits
+ninja-run: ninja launch
+
+# Uses meson to build the project
+meson-build:
+    meson build --prefix=/usr
+
+# Uses meson to reconfigure the project
+meson-reconfigure:
+    meson setup --reconfigure --prefix=/usr build
+
+# Launch the project
+launch:
+    ./build/src/com.github.sdv43.whaler
+
+# Install firefox for test xdg-open redirect
+install-test-browser:
+    paru -Syu --no-confirm firefox-bin alsa-lib


### PR DESCRIPTION
The just command runner does not require VSCode, this is good for non-vscode users.

VSCode tasks still exist but now use just