### PR TITLE
chore: 📄 Rename Whaler to "Whale Pilot" and update license

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,22 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Adwaita",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
 		"dockerfile": "./Dockerfile"
 	},
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "adw",
 	"runArgs": [
 		"--net=host",
 		"--volume=/var/run/docker.sock:/var/run/docker.sock",
 		"--device=/dev/dri"
 	],
+
+	// --- Mounts for VIM config file --- //
+	
+	//"mounts": [
+	//	"source=${localEnv:HOME}${localEnv:USERPROFILE}/.vimrc,target=/home/adw/.vimrc,type=bind,consistency=cached"
+	//],
+
+
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: flathub-infra/flatpak-github-actions/flatpak-builder@4388a4c5fc8bab58e1dfb7fc63267dca0f7b4976
       with:
         bundle: "pilot-whale-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak"
-        manifest-path: "com.github.jumpyvi.pilot-whale"
+        manifest-path: "com.github.jumpyvi.pilot-whale.yml"
         arch: x86_64
 
     - name: Publish release package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
 
     - uses: flathub-infra/flatpak-github-actions/flatpak-builder@4388a4c5fc8bab58e1dfb7fc63267dca0f7b4976
       with:
-        bundle: "whaler-gtk4-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak"
-        manifest-path: "com.github.sdv43.whaler.yml"
+        bundle: "blubber-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak"
+        manifest-path: "com.github.jumpyvi.blubber"
         arch: x86_64
 
     - name: Publish release package
@@ -45,4 +45,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.tag.outputs.release_tag }}
-        files: whaler-gtk4-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak
+        files: blubber-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
 
     - uses: flathub-infra/flatpak-github-actions/flatpak-builder@4388a4c5fc8bab58e1dfb7fc63267dca0f7b4976
       with:
-        bundle: "blubber-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak"
-        manifest-path: "com.github.jumpyvi.blubber"
+        bundle: "pilot-whale-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak"
+        manifest-path: "com.github.jumpyvi.pilot-whale"
         arch: x86_64
 
     - name: Publish release package
@@ -45,4 +45,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.tag.outputs.release_tag }}
-        files: blubber-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak
+        files: pilot-whale-${{ steps.tag.outputs.release_tag }}-x86_64.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       id: tag
       run: |
         TAG=$(sed -n "s/^.*version: '\([^']*\)'.*$/\1/p" meson.build | head -n1)
-        echo "release_tag=${TAG:-adw-0.0.1}" >> $GITHUB_OUTPUT
+        echo "release_tag=${TAG:-UNKOWN}" >> $GITHUB_OUTPUT
 
     - name: Create and push tag
       run: |

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,7 @@
         {
             "label": "Launch application",
             "type": "shell",
-            "command": "DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address` ./build/src/com.github.sdv43.whaler",
+            "command": "DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address` ./build/src/com.github.jumpyvi.blubber",
             "problemMatcher": [],
             "icon": {
                 "id": "run"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,7 @@
         {
             "label": "Launch application",
             "type": "shell",
-            "command": "DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address` ./build/src/com.github.jumpyvi.blubber",
+            "command": "DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address` ./build/src/com.github.jumpyvi.pilot-whale",
             "problemMatcher": [],
             "icon": {
                 "id": "run"

--- a/README.md
+++ b/README.md
@@ -1,48 +1,82 @@
-# Whaler GTK4
+# Pilot Whale container manager
 
 <div align="center">
- <img src="data/images/logo/64.png" alt="Whaler"/>
+ <img src="data/images/logo/64.png" alt="pilot-whale"/>
+ <p><b>Pilot your docker containers.</b></p>
+ <p><i>A fork of Whaler</i></p>
 </div>
 
-<p style="text-align:center;">Manage your container, Adwaita style</p>
 
 ![List of Docker containers](data/images/screenshots/screenshot-1.png?raw=true)
 
 ## Description
 
-### Fork disclamers
+### 👥 Fork disclamers
 
 This is a fork of [Whaler by sdv43](https://github.com/sdv43/whaler). This fork ports that project to GTK4 and libadwaita and adds some features.
 
-### About
+### 💫 About
 
-Whaler provides basic functionality for managing Docker containers. The app can start and stop both standalone containers and docker-compose applications. Also, it supports container logs viewing.
+Pilot Whale provides basic functionality for managing Docker containers. The app can start and stop both standalone containers and docker-compose applications. Also, it supports container logs viewing.
+
+It can also search images from DockerHub and pull images from anywhere.
 
 The solution is perfect for those who are looking for a simple tool to perform some basic actions. For the app to run correctly, make sure that Docker is installed on your system.
 
-## Installation
+## 📦 Installation
 
-Not yet available, see [building](#building) for now.
+This app is only officially packaged for Flatpak, you can download the latest flatpak package in the [releases](https://github.com/jumpyvi/pilot-whale/releases).
 
-## Usage with Podman
+To install it, simply do:
 
-1. Open Whaler
-2. An error-screen should appear
+```bash
+flatpak install pilot-whale-VERSION-ARCH.flatpak
+```
+
+> This app has access to your Docker and Podman sockets by default
+
+## 🚢 Usage with Podman
+
+1. Open Pilot Whale
+2. An error could appear (docker not detected), ignore it
 3. Click on the hamburger menu -> Preferences
 4. Replace the `API socket path` with something like `/run/user/1000/podman/podman.sock`
 
-## Development
+## 🛠️ Development
 
-Development can be done in a devcontainer. All dependencies are already present. Tasks and extensions are pre-configured for VSCode.
+Development should be done in a devcontainer. <br>
+All dependencies are already present in the devcontainer.
 
+
+### Before setting up your IDE
+* The socket at ``/var/run/docker.sock`` must have its permissions set to ``1000:docker``.
+
+* You also need to enable xhost local connection with ``xhost +local:docker``
+
+* To be able to test hyperlink in the app you can run ``just install-test-browser`` in the devcontainer
+
+### For VSCode
 1. Get VSCode, Docker and the devcontainer VSCode extension
-2. Set permission to /var/run/docker.sock to ``1000:docker``
-3. Create an empty folder ``~/.Xauthority``
-4. Open the project and run ``Dev Containers : Rebuild Container``
+2. Open the project and run ``Dev Containers : Rebuild Container``
+3. You can launch premade tasks from the VSCode task menu, this includes tasks for build and running the app.
 
-## Building
+### For vim
+1. Get devcontainer-cli from [linuxbrew](), [nixpkgs](https://search.nixos.org/packages?channel=24.11&show=devcontainer&from=0&size=50&sort=relevance&type=packages&query=devcontainer) or [npm](https://github.com/devcontainers/cli?tab=readme-ov-file#npm-install)
+2. If you want to use your own VIM config uncomment ``Mounts for VIM config file`` in [devcontainer.json](.devcontainer/devcontainer.json)
+3. From the project root run:
+```bash
+devcontainer up --workspace-folder $(pwd) && devcontainer exec --workspace-folder $(pwd) bash
+```
+4. You can now run vim or install another editor
+5. You can launch premade tasks with ``just --choose``, this includes tasks for build and running the app.
 
-You'll need the following dependencies:
+
+
+## 🏗️ Building locally, without the devcontainer
+
+### You'll need the following dependencies:
+> No need to manually download them if you use the devcontainer
+
 * gio-2.0
 * gtk4-devel
 * libgee-devel
@@ -55,9 +89,56 @@ You'll need the following dependencies:
 * ninja
 * valac
 
-### Meson
+### You can also get these optional tools for running tasks, code completion and generating doc:
 
-In project root:
+* just
+* fzf
+* valadoc
+* vala-language-server
+
+### Install all for Fedora 41
+> You will also need to manually get Docker for testing
+
+```bash
+sudo dnf install gtk4-devel ninja-build meson libadwaita-devel libgee-devel json-glib-devel desktop-file-utils libcurl-devel vala vala-language-server valadoc graphviz libglvnd just fzf
+```
+
+### Install all for Arch
+
+> I recommand using paru or yay
+
+```bash
+paru -Syu gtk4 ninja meson libadwaita libgee json-glib desktop-file-utils curl libglvnd vala-language-server vala docker just fzf
+```
+
+## 🔨 Building
+> All the command must be ran from the project root
+
+#### With [just](https://github.com/casey/just) (recommanded)
+
+First build of the project:
+```
+just init-build
+```
+
+Build the doc locally:
+```
+just generate-valadoc
+```
+
+Run ninja and launch the app
+```
+just ninja-run
+```
+
+Re-install the app
+```
+just install
+```
+
+
+#### Manually
+
 ```
 meson build --prefix=/usr
 cd build
@@ -66,10 +147,6 @@ ninja
 sudo ninja install
 ./build/src/com.github.sdv43.whaler
 ```
-
-### Flatpak
-
-Not yet available
 
 ## License
 This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) file for details.

--- a/com.github.jumpyvi.pilot-whale.yml
+++ b/com.github.jumpyvi.pilot-whale.yml
@@ -1,10 +1,10 @@
-id: com.github.jumpyvi.blubber
+id: com.github.jumpyvi.pilot-whale
 runtime: org.gnome.Platform
 runtime-version: "47"
 sdk: "org.gnome.Sdk"
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.vala
-command: "com.github.jumpyvi.blubber"
+command: "com.github.jumpyvi.pilot-whale"
 finish-args:
     - '--share=network'
     - '--share=ipc'
@@ -31,7 +31,7 @@ cleanup:
     - '*.la'
     - '*.a'
 modules:
-  - name: blubber
+  - name: pilot-whale
     buildsystem: meson
     sources:
       - type: dir

--- a/com.github.sdv43.whaler.yml
+++ b/com.github.sdv43.whaler.yml
@@ -1,10 +1,10 @@
-id: com.github.sdv43.whaler
+id: com.github.jumpyvi.blubber
 runtime: org.gnome.Platform
 runtime-version: "47"
 sdk: "org.gnome.Sdk"
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.vala
-command: "com.github.sdv43.whaler"
+command: "com.github.jumpyvi.blubber"
 finish-args:
     - '--share=network'
     - '--share=ipc'
@@ -31,7 +31,7 @@ cleanup:
     - '*.la'
     - '*.a'
 modules:
-  - name: whaler
+  - name: blubber
     buildsystem: meson
     sources:
       - type: dir

--- a/data/com.github.jumpyvi.blubber.appdata.xml.in
+++ b/data/com.github.jumpyvi.blubber.appdata.xml.in
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>com.github.sdv43.whaler</id>
-  <launchable type="desktop-id">com.github.sdv43.whaler.desktop</launchable>
-  <name>Whaler</name>
+  <id>com.github.jumpyvi.blubber</id>
+  <launchable type="desktop-id">com.github.jumpyvi.blubber.desktop</launchable>
+  <name>Blubber</name>
   <summary>Docker Container Management</summary>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <developer_name>Selivestrov Dmitriy</developer_name>
   <description>
     <p>
-      Whaler provides basic functionality for managing Docker containers.
+      Blubber provides basic functionality for managing Docker containers.
       The app can start and stop both standalone containers and docker-compose applications.
       Also, it supports viewing container logs.
     </p>

--- a/data/com.github.jumpyvi.blubber.desktop.in
+++ b/data/com.github.jumpyvi.blubber.desktop.in
@@ -1,10 +1,10 @@
 [Desktop Entry]
-Name=Whaler
+Name=Blubber
 GenericName=Docker Client
 Comment=Manage your Docker containers
 Categories=GTK;Development;Utility;
-Exec=com.github.sdv43.whaler
-Icon=com.github.sdv43.whaler
+Exec=com.github.jumpyvi.blubber
+Icon=com.github.jumpyvi.blubber
 Terminal=false
 Type=Application
 Keywords=Docker;Virtualizaton;Development;

--- a/data/com.github.jumpyvi.pilot-whale.appdata.xml.in
+++ b/data/com.github.jumpyvi.pilot-whale.appdata.xml.in
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>com.github.jumpyvi.blubber</id>
-  <launchable type="desktop-id">com.github.jumpyvi.blubber.desktop</launchable>
-  <name>Blubber</name>
+  <id>com.github.jumpyvi.pilot-whale</id>
+  <launchable type="desktop-id">com.github.jumpyvi.pilot-whale.desktop</launchable>
+  <name>Pilot Whale</name>
   <summary>Docker Container Management</summary>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
-  <developer_name>Selivestrov Dmitriy</developer_name>
+  <developer_name>Selivestrov Dmitriy, this port by @jumpyvi</developer_name>
   <description>
     <p>
-      Blubber provides basic functionality for managing Docker containers.
+      Pilot Whale provides basic functionality for managing Docker containers.
       The app can start and stop both standalone containers and docker-compose applications.
       Also, it supports viewing container logs.
     </p>

--- a/data/com.github.jumpyvi.pilot-whale.desktop.in
+++ b/data/com.github.jumpyvi.pilot-whale.desktop.in
@@ -1,10 +1,10 @@
 [Desktop Entry]
-Name=Blubber
-GenericName=Docker Client
+Name=Pilot Whale
+GenericName=Container Manager
 Comment=Manage your Docker containers
 Categories=GTK;Development;Utility;
-Exec=com.github.jumpyvi.blubber
-Icon=com.github.jumpyvi.blubber
+Exec=com.github.jumpyvi.pilot-whale
+Icon=com.github.jumpyvi.pilot-whale
 Terminal=false
 Type=Application
 Keywords=Docker;Virtualizaton;Development;

--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema path="/com/github/sdv43/whaler/" id="com.github.sdv43.whaler">
+  <schema path="/com/github/jumpyvi/blubber/" id="com.github.jumpyvi.blubber">
     <key name="window-position" type="(ii)">
       <default>(-1,-1)</default>
       <summary>Window position</summary>

--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema path="/com/github/jumpyvi/blubber/" id="com.github.jumpyvi.blubber">
+  <schema path="/com/github/jumpyvi/pilot-whale/" id="com.github.jumpyvi.pilot-whale">
     <key name="window-position" type="(ii)">
       <default>(-1,-1)</default>
       <summary>Window position</summary>

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,4 +1,4 @@
-application_id = 'com.github.jumpyvi.blubber'
+application_id = 'com.github.jumpyvi.pilot-whale'
 
 scalable_dir = 'hicolor' / 'scalable' / 'apps'
 install_data(

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,4 +1,4 @@
-application_id = 'com.github.sdv43.whaler'
+application_id = 'com.github.jumpyvi.blubber'
 
 scalable_dir = 'hicolor' / 'scalable' / 'apps'
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'com.github.jumpyvi.blubber',
+  'com.github.jumpyvi.pilot-whale',
   ['vala', 'c'],
   version: 'v4.2.2',
   meson_version: '>= 1.0.0',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'com.github.sdv43.whaler',
+  'com.github.jumpyvi.blubber',
   ['vala', 'c'],
   version: 'adw-0.1.3',
   meson_version: '>= 1.0.0',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'com.github.jumpyvi.blubber',
   ['vala', 'c'],
-  version: 'adw-0.1.3',
+  version: 'v4.2.2',
   meson_version: '>= 1.0.0',
   default_options: [
     'warning_level=2',

--- a/po/com.github.jumpyvi.pilot-whale.pot
+++ b/po/com.github.jumpyvi.pilot-whale.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: com.github.sdv43.whaler\n"
+"Project-Id-Version: com.github.jumpyvi.pilot-whale\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-13 21:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/src/Build.vala.in
+++ b/src/Build.vala.in
@@ -1,3 +1,16 @@
+/*
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+ */
+
 namespace Build {
     public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
     public const string APPLICATION_ID = @APPLICATION_ID@;

--- a/src/Build.vala.in
+++ b/src/Build.vala.in
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 namespace Build {

--- a/src/Docker/ApiClient.vala
+++ b/src/Docker/ApiClient.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Docker/ApiClient.vala
+++ b/src/Docker/ApiClient.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Docker/ContainerLogWatcher.vala
+++ b/src/Docker/ContainerLogWatcher.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Docker/ContainerLogWatcher.vala
+++ b/src/Docker/ContainerLogWatcher.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/State/Root.vala
+++ b/src/State/Root.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/State/Root.vala
+++ b/src/State/Root.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/State/ScreenDockerContainer.vala
+++ b/src/State/ScreenDockerContainer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/State/ScreenDockerContainer.vala
+++ b/src/State/ScreenDockerContainer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/State/ScreenMain.vala
+++ b/src/State/ScreenMain.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/State/ScreenMain.vala
+++ b/src/State/ScreenMain.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Utilities/ActionHandler.vala
+++ b/src/Utilities/ActionHandler.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Widgets;

--- a/src/Utilities/ActionHandler.vala
+++ b/src/Utilities/ActionHandler.vala
@@ -1,11 +1,16 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 using Widgets;
 
 class Utilities.ActionHandler {

--- a/src/Utilities/Constants.vala.in
+++ b/src/Utilities/Constants.vala.in
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 
@@ -16,7 +16,7 @@ namespace Utilities.Constants {
     const string APP_NAME = "Whaler";
     const string APP_ID = @APP_ID@;
     const string APP_VERSION = @APP_VERSION@;
-    const string RESOURCE_BASE = "/com/github/jumpyvi/blubber";
+    const string RESOURCE_BASE = "/com/github/jumpyvi/pilot-whale";
     const string LOCALE_DIR = @LOCALE_DIR@;
     const string DOCKER_ENGINE_SOCKET_PATH = "/run/docker.sock";
     const string DOCKER_ENIGINE_API_VERSION = "1.41";

--- a/src/Utilities/Constants.vala.in
+++ b/src/Utilities/Constants.vala.in
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,13 +7,16 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 
 namespace Utilities.Constants {
     const string APP_NAME = "Whaler";
     const string APP_ID = @APP_ID@;
     const string APP_VERSION = @APP_VERSION@;
-    const string RESOURCE_BASE = "/com/github/sdv43/whaler";
+    const string RESOURCE_BASE = "/com/github/jumpyvi/blubber";
     const string LOCALE_DIR = @LOCALE_DIR@;
     const string DOCKER_ENGINE_SOCKET_PATH = "/run/docker.sock";
     const string DOCKER_ENIGINE_API_VERSION = "1.41";

--- a/src/Utilities/DockerContainer.vala
+++ b/src/Utilities/DockerContainer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Docker;

--- a/src/Utilities/DockerContainer.vala
+++ b/src/Utilities/DockerContainer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Docker;

--- a/src/Utilities/Helpers.vala
+++ b/src/Utilities/Helpers.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 namespace Utilities {

--- a/src/Utilities/Helpers.vala
+++ b/src/Utilities/Helpers.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 namespace Utilities {

--- a/src/Utilities/HttpClient.vala
+++ b/src/Utilities/HttpClient.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 namespace Utilities {

--- a/src/Utilities/HttpClient.vala
+++ b/src/Utilities/HttpClient.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 namespace Utilities {

--- a/src/Utilities/Reloader.vala
+++ b/src/Utilities/Reloader.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 public class Utilities.Reloader {

--- a/src/Utilities/Reloader.vala
+++ b/src/Utilities/Reloader.vala
@@ -1,3 +1,16 @@
+/*
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+ */
+
 public class Utilities.Reloader {
     public static void reload (){
         var state = State.Root.get_instance ();

--- a/src/Utilities/Sorting/SortingInterface.vala
+++ b/src/Utilities/Sorting/SortingInterface.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 interface Utilities.Sorting.SortingInterface : Object {

--- a/src/Utilities/Sorting/SortingInterface.vala
+++ b/src/Utilities/Sorting/SortingInterface.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 interface Utilities.Sorting.SortingInterface : Object {

--- a/src/Utilities/Sorting/SortingName.vala
+++ b/src/Utilities/Sorting/SortingName.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 class Utilities.Sorting.SortingName : Object, SortingInterface {

--- a/src/Utilities/Sorting/SortingName.vala
+++ b/src/Utilities/Sorting/SortingName.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 class Utilities.Sorting.SortingName : Object, SortingInterface {

--- a/src/Utilities/Sorting/SortingStatus.vala
+++ b/src/Utilities/Sorting/SortingStatus.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 class Utilities.Sorting.SortingStatus : Object, SortingInterface {

--- a/src/Utilities/Sorting/SortingStatus.vala
+++ b/src/Utilities/Sorting/SortingStatus.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 class Utilities.Sorting.SortingStatus : Object, SortingInterface {

--- a/src/Utilities/Sorting/SortingType.vala
+++ b/src/Utilities/Sorting/SortingType.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 class Utilities.Sorting.SortingType : Object, SortingInterface {

--- a/src/Utilities/Sorting/SortingType.vala
+++ b/src/Utilities/Sorting/SortingType.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 class Utilities.Sorting.SortingType : Object, SortingInterface {

--- a/src/Widgets/Dialogs/ImagesSearchDialog.vala
+++ b/src/Widgets/Dialogs/ImagesSearchDialog.vala
@@ -110,7 +110,7 @@ class Widgets.Dialogs.ImagesSearchDialog : Adw.Dialog {
         Utils.PullButton pull_button = new Utils.PullButton();
         other_registries_box.halign = Gtk.Align.BASELINE_CENTER;
 
-        var settings = new GLib.Settings("com.github.jumpyvi.Blubber");
+        var settings = new GLib.Settings("com.github.jumpyvi.blubber");
         string[] valid_registries = settings.get_strv("valid-registry-prefixes");
 
         var registry_model = new Gtk.StringList(valid_registries);

--- a/src/Widgets/Dialogs/ImagesSearchDialog.vala
+++ b/src/Widgets/Dialogs/ImagesSearchDialog.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,7 +7,9 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
-*/
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+ */
 
 using Utilities;
 using Docker;
@@ -108,7 +110,7 @@ class Widgets.Dialogs.ImagesSearchDialog : Adw.Dialog {
         Utils.PullButton pull_button = new Utils.PullButton();
         other_registries_box.halign = Gtk.Align.BASELINE_CENTER;
 
-        var settings = new GLib.Settings("com.github.sdv43.whaler");
+        var settings = new GLib.Settings("com.github.jumpyvi.Blubber");
         string[] valid_registries = settings.get_strv("valid-registry-prefixes");
 
         var registry_model = new Gtk.StringList(valid_registries);

--- a/src/Widgets/Dialogs/ImagesSearchDialog.vala
+++ b/src/Widgets/Dialogs/ImagesSearchDialog.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;
@@ -110,7 +110,7 @@ class Widgets.Dialogs.ImagesSearchDialog : Adw.Dialog {
         Utils.PullButton pull_button = new Utils.PullButton();
         other_registries_box.halign = Gtk.Align.BASELINE_CENTER;
 
-        var settings = new GLib.Settings("com.github.jumpyvi.blubber");
+        var settings = new GLib.Settings("com.github.jumpyvi.pilot-whale");
         string[] valid_registries = settings.get_strv("valid-registry-prefixes");
 
         var registry_model = new Gtk.StringList(valid_registries);

--- a/src/Widgets/Dialogs/SettingsWindow.vala
+++ b/src/Widgets/Dialogs/SettingsWindow.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,7 +7,10 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 using Utilities.Constants;
 
 class Widgets.Dialogs.SettingsWindow : Adw.PreferencesDialog {
@@ -66,7 +69,7 @@ private Adw.PreferencesPage get_pref(){
     var privacy_policy_row = new Adw.ActionRow();
     privacy_policy_row.activatable = false;
     privacy_policy_row.title = _( "Privacy Policy" );
-    privacy_policy_row.subtitle = _( "Whaler collects absolutely nothing. \nDockerHub, registries and pulled images might." );
+    privacy_policy_row.subtitle = _( "Blubber collects absolutely nothing. \nDockerHub, registries and pulled images might." );
     privacy_group.add(privacy_policy_row);
 
     page.add(docker_group);

--- a/src/Widgets/Dialogs/SettingsWindow.vala
+++ b/src/Widgets/Dialogs/SettingsWindow.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities.Constants;
@@ -69,7 +69,7 @@ private Adw.PreferencesPage get_pref(){
     var privacy_policy_row = new Adw.ActionRow();
     privacy_policy_row.activatable = false;
     privacy_policy_row.title = _( "Privacy Policy" );
-    privacy_policy_row.subtitle = _( "Blubber collects absolutely nothing. \nDockerHub, registries and pulled images might." );
+    privacy_policy_row.subtitle = _( "Pilot Whale collects absolutely nothing. \nDockerHub, registries and pulled images might." );
     privacy_group.add(privacy_policy_row);
 
     page.add(docker_group);

--- a/src/Widgets/ScreenDockerContainer.vala
+++ b/src/Widgets/ScreenDockerContainer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/ScreenDockerContainer.vala
+++ b/src/Widgets/ScreenDockerContainer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/ScreenError.vala
+++ b/src/Widgets/ScreenError.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Gtk;

--- a/src/Widgets/ScreenError.vala
+++ b/src/Widgets/ScreenError.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Gtk;

--- a/src/Widgets/ScreenMain.vala
+++ b/src/Widgets/ScreenMain.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Widgets.Screens.Main;

--- a/src/Widgets/ScreenMain.vala
+++ b/src/Widgets/ScreenMain.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Widgets.Screens.Main;

--- a/src/Widgets/ScreenManager.vala
+++ b/src/Widgets/ScreenManager.vala
@@ -1,10 +1,14 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 public class Widgets.ScreenManager : Gtk.Box {

--- a/src/Widgets/ScreenManager.vala
+++ b/src/Widgets/ScreenManager.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 public class Widgets.ScreenManager : Gtk.Box {

--- a/src/Widgets/Screens/DockerContainer/LogViewer.vala
+++ b/src/Widgets/Screens/DockerContainer/LogViewer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/LogViewer.vala
+++ b/src/Widgets/Screens/DockerContainer/LogViewer.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/SideBar.vala
+++ b/src/Widgets/Screens/DockerContainer/SideBar.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/SideBar.vala
+++ b/src/Widgets/Screens/DockerContainer/SideBar.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/SideBarItem.vala
+++ b/src/Widgets/Screens/DockerContainer/SideBarItem.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/SideBarItem.vala
+++ b/src/Widgets/Screens/DockerContainer/SideBarItem.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/SideBarSeparator.vala
+++ b/src/Widgets/Screens/DockerContainer/SideBarSeparator.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 class Widgets.Screens.Container.SideBarSeparator : Gtk.ListBoxRow {

--- a/src/Widgets/Screens/DockerContainer/SideBarSeparator.vala
+++ b/src/Widgets/Screens/DockerContainer/SideBarSeparator.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 class Widgets.Screens.Container.SideBarSeparator : Gtk.ListBoxRow {

--- a/src/Widgets/Screens/DockerContainer/TopBar.vala
+++ b/src/Widgets/Screens/DockerContainer/TopBar.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/TopBar.vala
+++ b/src/Widgets/Screens/DockerContainer/TopBar.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/TopBarActions.vala
+++ b/src/Widgets/Screens/DockerContainer/TopBarActions.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/DockerContainer/TopBarActions.vala
+++ b/src/Widgets/Screens/DockerContainer/TopBarActions.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/Main/ContainerCard.vala
+++ b/src/Widgets/Screens/Main/ContainerCard.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/Main/ContainerCard.vala
+++ b/src/Widgets/Screens/Main/ContainerCard.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/Main/ContainerCardActions.vala
+++ b/src/Widgets/Screens/Main/ContainerCardActions.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/Main/ContainerCardActions.vala
+++ b/src/Widgets/Screens/Main/ContainerCardActions.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Screens/Main/ContainersGrid.vala
+++ b/src/Widgets/Screens/Main/ContainersGrid.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 public class Widgets.Screens.Main.ContainersGrid : Adw.Bin {

--- a/src/Widgets/Screens/Main/ContainersGrid.vala
+++ b/src/Widgets/Screens/Main/ContainersGrid.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 public class Widgets.Screens.Main.ContainersGrid : Adw.Bin {

--- a/src/Widgets/Screens/Main/ContainersGridFilter.vala
+++ b/src/Widgets/Screens/Main/ContainersGridFilter.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities.Sorting;

--- a/src/Widgets/Screens/Main/ContainersGridFilter.vala
+++ b/src/Widgets/Screens/Main/ContainersGridFilter.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities.Sorting;

--- a/src/Widgets/Utils/ActionMenu.vala
+++ b/src/Widgets/Utils/ActionMenu.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Utils/ActionMenu.vala
+++ b/src/Widgets/Utils/ActionMenu.vala
@@ -1,3 +1,16 @@
+/*
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+ */
+
 using Utilities;
 using Widgets;
 using Posix;

--- a/src/Widgets/Utils/BackButton.vala
+++ b/src/Widgets/Utils/BackButton.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 public class Widgets.Utils.BackButton : Gtk.Button {

--- a/src/Widgets/Utils/BackButton.vala
+++ b/src/Widgets/Utils/BackButton.vala
@@ -1,10 +1,14 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 public class Widgets.Utils.BackButton : Gtk.Button {

--- a/src/Widgets/Utils/ContainerInfoDialog.vala
+++ b/src/Widgets/Utils/ContainerInfoDialog.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Utils/ContainerInfoDialog.vala
+++ b/src/Widgets/Utils/ContainerInfoDialog.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,6 +7,8 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Utils/DockerContainerStatusLabel.vala
+++ b/src/Widgets/Utils/DockerContainerStatusLabel.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Utils/DockerContainerStatusLabel.vala
+++ b/src/Widgets/Utils/DockerContainerStatusLabel.vala
@@ -1,11 +1,16 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
    Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 using Utilities;
 
 namespace Widgets.Utils {

--- a/src/Widgets/Utils/ImageCard.vala
+++ b/src/Widgets/Utils/ImageCard.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Docker;

--- a/src/Widgets/Utils/ImageCard.vala
+++ b/src/Widgets/Utils/ImageCard.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,7 +7,10 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 using Docker;
 using Adw;
 using Utilities;

--- a/src/Widgets/Utils/ImagesSearchBar.vala
+++ b/src/Widgets/Utils/ImagesSearchBar.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Docker;

--- a/src/Widgets/Utils/ImagesSearchBar.vala
+++ b/src/Widgets/Utils/ImagesSearchBar.vala
@@ -1,10 +1,14 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Docker;

--- a/src/Widgets/Utils/ImagesSearchButton.vala
+++ b/src/Widgets/Utils/ImagesSearchButton.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 

--- a/src/Widgets/Utils/ImagesSearchButton.vala
+++ b/src/Widgets/Utils/ImagesSearchButton.vala
@@ -1,11 +1,17 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
+
 using Utilities;
 using Widgets.Dialogs;
 public class Widgets.Utils.ImagesSearchButton : Gtk.Button{

--- a/src/Widgets/Utils/MainAction.vala
+++ b/src/Widgets/Utils/MainAction.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities;

--- a/src/Widgets/Utils/MainAction.vala
+++ b/src/Widgets/Utils/MainAction.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Whaler.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -7,7 +7,10 @@
    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 using Utilities;
 using Widgets.Utils;
 

--- a/src/Widgets/Utils/PullButton.vala
+++ b/src/Widgets/Utils/PullButton.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 

--- a/src/Widgets/Utils/PullButton.vala
+++ b/src/Widgets/Utils/PullButton.vala
@@ -1,11 +1,17 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
+
 using Docker;
 class Widgets.Utils.PullButton : Gtk.Button {
     public string image_name;

--- a/src/Widgets/Utils/ReloadButton.vala
+++ b/src/Widgets/Utils/ReloadButton.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,7 +8,7 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
  using Utilities;

--- a/src/Widgets/Utils/ReloadButton.vala
+++ b/src/Widgets/Utils/ReloadButton.vala
@@ -1,11 +1,16 @@
 /*
- * This file is part of Whaler.
- * Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- * Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
  using Utilities;
  public class Widgets.Utils.ReloadButton : Gtk.Button {
     private Adw.ButtonContent button_content = new Adw.ButtonContent ();

--- a/src/application.vala
+++ b/src/application.vala
@@ -63,12 +63,12 @@ public class Blubber.Application : Adw.Application {
             translator_credits = _("translator-credits"),
             version = Build.VERSION,
             license_type = Gtk.License.GPL_3_0,
-            issue_url = "https://www.github.com/jumpyvi/Blubber-gtk4/issues",
+            issue_url = "https://github.com/jumpyvi/blubber/issues",
         };
-        about.add_credit_section ("Original code from Blubber", {"sdv43"});
-        about.add_credit_section ("Adwaita fork", {"jumpyvi"});
-        about.add_link ("Get source code", "https://www.github.com/jumpyvi/Blubber-gtk4");
-        about.add_link ("Get original project", "https://www.github.com/sdv43/Blubber");
+        about.add_credit_section ("Original code from Whaler", {"sdv43"});
+        about.add_credit_section ("The Bubbler fork (this)", {"jumpyvi"});
+        about.add_link ("Get source code", "https://github.com/jumpyvi/blubber");
+        about.add_link ("Get original project", "https://www.github.com/sdv43/whaler");
 
         about.present (this.active_window);
     }

--- a/src/application.vala
+++ b/src/application.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,16 +8,16 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Widgets;
 
 
-public class Blubber.Application : Adw.Application {
+public class PilotWhale.Application : Adw.Application {
     public Application () {
         Object (
-            application_id: "com.github.jumpyvi.blubber",
+            application_id: "com.github.jumpyvi.pilot-whale",
             flags: ApplicationFlags.DEFAULT_FLAGS
         );
     }
@@ -35,7 +35,7 @@ public class Blubber.Application : Adw.Application {
 
     public override void activate () {
         base.activate ();
-        var win = this.active_window ?? new Blubber.Window (this);
+        var win = this.active_window ?? new PilotWhale.Window (this);
 
         // --- Error Widget test --- //
         //var error_widget = ScreenError.build_error_docker_not_avialable (
@@ -45,7 +45,7 @@ public class Blubber.Application : Adw.Application {
         //            ScreenManager.screen_error_show_widget (error_widget); 
 
         var provider = new Gtk.CssProvider ();
-		provider.load_from_resource ("/com/github/blubber/Blubber/index.css");
+		provider.load_from_resource ("/com/github/jumpyvi/pilot-whale/index.css");
 
         // Nothing has replaced this yet, will need to be update when gtk5 releases
 		Gtk.StyleContext.add_provider_for_display (
@@ -57,17 +57,17 @@ public class Blubber.Application : Adw.Application {
 
     private void on_about_action () {
         var about = new Adw.AboutDialog () {
-            application_name = "Blubber",
-            application_icon = "com.github.jumpyvi.blubber",
-            developer_name = "Blubber Developpers",
+            application_name = "Pilot Whale",
+            application_icon = "com.github.jumpyvi.pilot-whale",
+            developer_name = "Pilot Whale Developpers",
             translator_credits = _("translator-credits"),
             version = Build.VERSION,
             license_type = Gtk.License.GPL_3_0,
-            issue_url = "https://github.com/jumpyvi/blubber/issues",
+            issue_url = "https://github.com/jumpyvi/pilot-whale/issues",
         };
         about.add_credit_section ("Original code from Whaler", {"sdv43"});
-        about.add_credit_section ("The Bubbler fork (this)", {"jumpyvi"});
-        about.add_link ("Get source code", "https://github.com/jumpyvi/blubber");
+        about.add_credit_section ("The Pilot Whale fork (this)", {"jumpyvi"});
+        about.add_link ("Get source code", "https://github.com/jumpyvi/pilot-whale");
         about.add_link ("Get original project", "https://www.github.com/sdv43/whaler");
 
         about.present (this.active_window);

--- a/src/application.vala
+++ b/src/application.vala
@@ -1,30 +1,23 @@
-/* application.vala
- *
- * Copyright 2025 Whaler Developpers
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
+/*
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Widgets;
 
 
-public class Whaler.Application : Adw.Application {
+public class Blubber.Application : Adw.Application {
     public Application () {
         Object (
-            application_id: "com.github.sdv43.whaler",
+            application_id: "com.github.jumpyvi.blubber",
             flags: ApplicationFlags.DEFAULT_FLAGS
         );
     }
@@ -42,7 +35,7 @@ public class Whaler.Application : Adw.Application {
 
     public override void activate () {
         base.activate ();
-        var win = this.active_window ?? new Whaler.Window (this);
+        var win = this.active_window ?? new Blubber.Window (this);
 
         // --- Error Widget test --- //
         //var error_widget = ScreenError.build_error_docker_not_avialable (
@@ -52,7 +45,7 @@ public class Whaler.Application : Adw.Application {
         //            ScreenManager.screen_error_show_widget (error_widget); 
 
         var provider = new Gtk.CssProvider ();
-		provider.load_from_resource ("/com/github/sdv43/whaler/index.css");
+		provider.load_from_resource ("/com/github/blubber/Blubber/index.css");
 
         // Nothing has replaced this yet, will need to be update when gtk5 releases
 		Gtk.StyleContext.add_provider_for_display (
@@ -64,18 +57,18 @@ public class Whaler.Application : Adw.Application {
 
     private void on_about_action () {
         var about = new Adw.AboutDialog () {
-            application_name = "whaler",
-            application_icon = "com.github.sdv43.whaler",
-            developer_name = "Whaler Developpers",
+            application_name = "Blubber",
+            application_icon = "com.github.jumpyvi.blubber",
+            developer_name = "Blubber Developpers",
             translator_credits = _("translator-credits"),
             version = Build.VERSION,
             license_type = Gtk.License.GPL_3_0,
-            issue_url = "https://www.github.com/jumpyvi/whaler-gtk4/issues",
+            issue_url = "https://www.github.com/jumpyvi/Blubber-gtk4/issues",
         };
-        about.add_credit_section ("Original code and project", {"sdv43"});
+        about.add_credit_section ("Original code from Blubber", {"sdv43"});
         about.add_credit_section ("Adwaita fork", {"jumpyvi"});
-        about.add_link ("Get source code", "https://www.github.com/jumpyvi/whaler-gtk4");
-        about.add_link ("Get original project", "https://www.github.com/sdv43/whaler");
+        about.add_link ("Get source code", "https://www.github.com/jumpyvi/Blubber-gtk4");
+        about.add_link ("Get original project", "https://www.github.com/sdv43/Blubber");
 
         about.present (this.active_window);
     }

--- a/src/blubber.gresource.xml
+++ b/src/blubber.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/com/github/sdv43/whaler">
+  <gresource prefix="/com/github/jumpyvi/blubber">
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
     

--- a/src/main.vala
+++ b/src/main.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,13 +8,13 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities.Constants;
 int main (string[] args) {
     Intl.bindtextdomain (APP_ID, LOCALE_DIR);
 
-    var app = new Blubber.Application ();
+    var app = new PilotWhale.Application ();
     return app.run (args);
 }

--- a/src/main.vala
+++ b/src/main.vala
@@ -1,27 +1,20 @@
-/* main.vala
- *
- * Copyright 2025 Whaler Developpers
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
+/*
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
 
 using Utilities.Constants;
 int main (string[] args) {
     Intl.bindtextdomain (APP_ID, LOCALE_DIR);
 
-    var app = new Whaler.Application ();
+    var app = new Blubber.Application ();
     return app.run (args);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 configuration = configuration_data()
-configuration.set_quoted('GETTEXT_PACKAGE', 'whaler')
-configuration.set_quoted('APPLICATION_ID', 'com.github.sdv43.whaler')
+configuration.set_quoted('GETTEXT_PACKAGE', 'blubber')
+configuration.set_quoted('APPLICATION_ID', 'com.github.jumpyvi.blubber')
 configuration.set_quoted('VERSION', meson.project_version())
 configuration.set_quoted('PREFIX', get_option('prefix'))
 configuration.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))
@@ -85,7 +85,7 @@ sources = [
 
 
 
-whaler_deps = [
+blubber_deps = [
   dependency('gtk4'),
   dependency('libadwaita-1', version: '>= 1.4'),
   dependency('libadwaita-1', version: '>= 1.4'),
@@ -97,7 +97,7 @@ whaler_deps = [
   meson.get_compiler('c').find_library('libcurl', dirs: vapi_dir),
 ]
 
-sources += gnome.compile_resources('whaler-resources', 'whaler.gresource.xml', c_name: 'whaler')
+sources += gnome.compile_resources('blubber-resources', 'blubber.gresource.xml', c_name: 'blubber')
 
 sources += configure_file(
     input : 'Build.vala.in',
@@ -109,7 +109,7 @@ executable(
   meson.project_name(),
   constants,
   sources,
-  dependencies: whaler_deps,
+  dependencies: blubber_deps,
   install: true,
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 configuration = configuration_data()
-configuration.set_quoted('GETTEXT_PACKAGE', 'blubber')
-configuration.set_quoted('APPLICATION_ID', 'com.github.jumpyvi.blubber')
+configuration.set_quoted('GETTEXT_PACKAGE', 'pilot-whale')
+configuration.set_quoted('APPLICATION_ID', 'com.github.jumpyvi.pilot-whale')
 configuration.set_quoted('VERSION', meson.project_version())
 configuration.set_quoted('PREFIX', get_option('prefix'))
 configuration.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))
@@ -85,7 +85,7 @@ sources = [
 
 
 
-blubber_deps = [
+pilotwhale_deps = [
   dependency('gtk4'),
   dependency('libadwaita-1', version: '>= 1.4'),
   dependency('libadwaita-1', version: '>= 1.4'),
@@ -97,7 +97,7 @@ blubber_deps = [
   meson.get_compiler('c').find_library('libcurl', dirs: vapi_dir),
 ]
 
-sources += gnome.compile_resources('blubber-resources', 'blubber.gresource.xml', c_name: 'blubber')
+sources += gnome.compile_resources('pilotwhale-resources', 'pilot-whale.gresource.xml', c_name: 'pilotwhale')
 
 sources += configure_file(
     input : 'Build.vala.in',
@@ -109,7 +109,7 @@ executable(
   meson.project_name(),
   constants,
   sources,
-  dependencies: blubber_deps,
+  dependencies: pilotwhale_deps,
   install: true,
 )
 

--- a/src/pilot-whale.gresource.xml
+++ b/src/pilot-whale.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/com/github/jumpyvi/blubber">
+  <gresource prefix="/com/github/jumpyvi/pilot-whale">
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
     

--- a/src/window.ui
+++ b/src/window.ui
@@ -2,8 +2,8 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
   <requires lib="Adw" version="1.0"/>
-  <template class="WhalerWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="yes">Whaler</property>
+  <template class="BlubberWindow" parent="AdwApplicationWindow">
+    <property name="title" translatable="yes">Blubber</property>
     <property name="default-width">800</property>
     <property name="default-height">600</property>
     <property name="content">
@@ -40,7 +40,7 @@
         <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">_About NewWhaler</attribute>
+        <attribute name="label" translatable="yes">_About Blubber</attribute>
         <attribute name="action">app.about</attribute>
       </item>
     </section>

--- a/src/window.ui
+++ b/src/window.ui
@@ -2,8 +2,8 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
   <requires lib="Adw" version="1.0"/>
-  <template class="BlubberWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="yes">Blubber</property>
+  <template class="PilotWhaleWindow" parent="AdwApplicationWindow">
+    <property name="title" translatable="yes">Pilot Whale</property>
     <property name="default-width">800</property>
     <property name="default-height">600</property>
     <property name="content">
@@ -40,7 +40,7 @@
         <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">_About Blubber</attribute>
+        <attribute name="label" translatable="yes">_About Pilot Whale</attribute>
         <attribute name="action">app.about</attribute>
       </item>
     </section>

--- a/src/window.vala
+++ b/src/window.vala
@@ -1,28 +1,22 @@
-/* window.vala
- *
- * Copyright 2025 Whaler Developpers
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
+/*
+   This file is part of Bubbler, a fork of Whaler by sdv43.
+
+   Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+   Whaler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
+
+   This fork, Bubbler, was created and modified by jumpyvi in 2025.
  */
+
 using Widgets;
 using Widgets.Utils;
 using Adw;
 
-[GtkTemplate (ui = "/com/github/sdv43/whaler/window.ui")]
-public class Whaler.Window : Adw.ApplicationWindow {
+[GtkTemplate (ui = "/com/github/jumpyvi/blubber/window.ui")]
+public class Blubber.Window : Adw.ApplicationWindow {
     [GtkChild]
     private unowned Adw.Bin screen_manager_placeholder;
     [GtkChild]

--- a/src/window.vala
+++ b/src/window.vala
@@ -1,5 +1,5 @@
 /*
-   This file is part of Bubbler, a fork of Whaler by sdv43.
+   This file is part of Pilot Whale, a fork of Whaler by sdv43.
 
    Whaler is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -8,15 +8,15 @@
 
    You should have received a copy of the GNU General Public License along with Whaler. If not, see <https://www.gnu.org/licenses/>.
 
-   This fork, Bubbler, was created and modified by jumpyvi in 2025.
+   This fork, Pilot Whale, was created and modified by jumpyvi in 2025.
  */
 
 using Widgets;
 using Widgets.Utils;
 using Adw;
 
-[GtkTemplate (ui = "/com/github/jumpyvi/blubber/window.ui")]
-public class Blubber.Window : Adw.ApplicationWindow {
+[GtkTemplate (ui = "/com/github/jumpyvi/pilot-whale/window.ui")]
+public class PilotWhale.Window : Adw.ApplicationWindow {
     [GtkChild]
     private unowned Adw.Bin screen_manager_placeholder;
     [GtkChild]


### PR DESCRIPTION
# Why
As this version of Whaler does not follow the visual guideline of ElementaryOS, this is now its own project.

# Name resoning
Pilot -> You "pilot" containers
Whale -> The mascot of docker

Pilot whale -> https://en.wikipedia.org/wiki/Pilot_whale

# Changes
* Most of the references to Whaler are changed to Pilot Whale (except when referring to the original)
* License modifications to follow GPLv3
* README changes
* New versioning format (gtk_version.major.minor)