### PR TITLE
fix: :bug: Fix the container info dialog not being expended

### DIFF
--- a/src/Widgets/Utils/ActionMenu.vala
+++ b/src/Widgets/Utils/ActionMenu.vala
@@ -133,7 +133,6 @@ class Widgets.Utils.ActionMenu : Adw.Bin {
         var state = State.Root.get_instance ();
 
         info_button.clicked.connect (() => {
-            print("info..");
             info_button.sensitive = false;
             
             state.container_inspect.begin (container, (_, res) => {

--- a/src/Widgets/Utils/ContainerInfoDialog.vala
+++ b/src/Widgets/Utils/ContainerInfoDialog.vala
@@ -74,8 +74,10 @@ class Widgets.Utils.ContainerInfoDialog : Adw.Dialog {
         }
 
         scrolled_window.set_child (box);
-        scrolled_window.margin_start = 10;
-        scrolled_window.margin_top = 10;
+        scrolled_window.set_vexpand (true);
+        scrolled_window.margin_start = 9;
+        scrolled_window.margin_top = 9;
+        scrolled_window.margin_bottom = 9;
 
         return scrolled_window;
     }


### PR DESCRIPTION
fix #14 

The info text now takes all the space it can.